### PR TITLE
fetchCheriSDK.groovy: Build demo-2024-06 with custom Morello LLVM

### DIFF
--- a/vars/fetchCheriSDK.groovy
+++ b/vars/fetchCheriSDK.groovy
@@ -62,6 +62,8 @@ def call(Map args) {
         // morello%2F (Jenkins URL-encodes the branch name)
         if (gitBranch == 'abi-breaking-changes' || gitBranch == 'upstream-llvm-merge')
             params.morelloLlvmBranch = 'morello%2Fdev'
+        else if (gitBranch == 'demo-2024-06')
+            params.morelloLlvmBranch = 'elf_sig'
         else
             params.morelloLlvmBranch = "morello%2F${params.llvmBranch}"
     }


### PR DESCRIPTION
This demo branch needs to be built with a Morello LLVM branch that emits function signatures and wraps function pointers in trampolines.