### PR TITLE
Build the kernel-c18n branch of CheriBSD with custom LLVM branches

### DIFF
--- a/vars/fetchCheriSDK.groovy
+++ b/vars/fetchCheriSDK.groovy
@@ -48,7 +48,8 @@ def call(Map args) {
         gitBranch = env.BRANCH_NAME
     }
     if (!params.llvmBranch) {
-        if (gitBranch in ['c18n', 'caprevoke', 'cocall', 'cocalls', 'coexecve', 'dev', 'devel', 'demo-2024-03'])
+        if (gitBranch in ['c18n', 'caprevoke', 'cocall', 'cocalls', 'coexecve',
+                          'dev', 'devel', 'demo-2024-03', 'kernel-c18n'])
             params.llvmBranch = 'dev'
         else if (gitBranch == 'abi-breaking-changes')
             params.llvmBranch = 'abi-breaking-changes'
@@ -65,6 +66,8 @@ def call(Map args) {
             params.morelloLlvmBranch = 'morello%2Fdev'
         else if (gitBranch == 'demo-2024-06')
             params.morelloLlvmBranch = 'elf_sig'
+        else if (gitBranch == 'kernel-c18n')
+            params.morelloLlvmBranch = 'kernel-c18n'
         else
             params.morelloLlvmBranch = "morello%2F${params.llvmBranch}"
     }


### PR DESCRIPTION
Use the dev branch of CHERI LLVM when building for CHERI-RISC-V and the kernel-c18n branch of CHERI LLVM for Morello when building for Morello.

On Morello, the kernel-c18n branch of CheriBSD uses relocations for function pointers. CHERI-RISC-V is not supported yet but should at least build.

Corresponding changes:
* https://github.com/CTSRD-CHERI/cheribsd/pull/2224
* https://github.com/CTSRD-CHERI/cheribsd-deploy-scripts/pull/1