### PR TITLE
fetchCheriSDK.groovy: Treat all c18n* branches like dev

### DIFF
--- a/vars/fetchCheriSDK.groovy
+++ b/vars/fetchCheriSDK.groovy
@@ -48,9 +48,9 @@ def call(Map args) {
         gitBranch = env.BRANCH_NAME
     }
     if (!params.llvmBranch) {
-        if (gitBranch in ['c18n', 'caprevoke', 'cocall', 'cocalls', 'coexecve',
-                          'dev', 'devel', 'demo-2024-03', 'kernel-c18n', 'demo-2024-10',
-                          'linux-next'])
+        if (gitBranch in ['caprevoke', 'cocall', 'cocalls', 'coexecve', 'dev', 'devel',
+                          'demo-2024-03', 'kernel-c18n', 'demo-2024-10', 'linux-next'] ||
+            gitBranch.startsWith('c18n')))
             params.llvmBranch = 'dev'
         else if (gitBranch == 'abi-breaking-changes')
             params.llvmBranch = 'abi-breaking-changes'


### PR DESCRIPTION
Saves us the effort of editing this file for every c18n feature branch that requires the dev compiler.