### PR TITLE
fetchCheriSDK.groovy: Use dev compiler by default

### DIFF
--- a/vars/fetchCheriSDK.groovy
+++ b/vars/fetchCheriSDK.groovy
@@ -48,16 +48,14 @@ def call(Map args) {
         gitBranch = env.BRANCH_NAME
     }
     if (!params.llvmBranch) {
-        if (gitBranch in ['c18n', 'caprevoke', 'cocall', 'cocalls', 'coexecve',
-                          'dev', 'devel', 'demo-2024-03', 'kernel-c18n', 'demo-2024-10',
-                          'linux-next'])
-            params.llvmBranch = 'dev'
+        if (gitBranch == 'main')
+            params.llvmBranch = 'master'
         else if (gitBranch == 'abi-breaking-changes')
             params.llvmBranch = 'abi-breaking-changes'
         else if (gitBranch == 'upstream-llvm-merge')
             params.llvmBranch = 'upstream-llvm-merge'
         else
-            params.llvmBranch = 'master'
+            params.llvmBranch = 'dev'
         // echo("Inferred LLVM branch from current git branch (${gitBranch}): ${params.llvmBranch}")
     }
     if (!params.morelloLlvmBranch) {


### PR DESCRIPTION
Previously only a few named branches of CheriBSD (including dev) get built by the dev compiler. This creates a situation where CheriBSD PRs are built by the main compiler but merged into the dev branch, which is built by the dev compiler.

This commit changes the default to use the dev compiler and only the main branch uses the master compiler.